### PR TITLE
Prevent evaluating the queryset during max_pk calculation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         django-version: ["1.11.29", "2.0", "2.1", "2.2"]

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -91,9 +91,10 @@ def do_update(
 
     # Remember maximum PK seen so far
     max_pk = None
-    current_qs = list(current_qs)
-    if current_qs:
-        max_pk = current_qs[-1].pk
+    # current_qs = list(current_qs)
+    if current_qs.exists():
+        # Using .count() to prevent evaluating the QuerySet
+        max_pk = current_qs[current_qs.count() - 1].pk
 
     is_parent_process = hasattr(os, "getppid") and os.getpid() == os.getppid()
 

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -91,10 +91,10 @@ def do_update(
 
     # Remember maximum PK seen so far
     max_pk = None
-    # current_qs = list(current_qs)
-    if current_qs.exists():
-        # Using .count() to prevent evaluating the QuerySet
-        max_pk = current_qs[current_qs.count() - 1].pk
+    max_pk_index = current_qs.count() - 1
+    if max_pk_index > -1:
+        max_pk_qs = current_qs[max_pk_index:max_pk_index + 1]
+        max_pk = max_pk_qs[0].pk
 
     is_parent_process = hasattr(os, "getppid") and os.getpid() == os.getppid()
 


### PR DESCRIPTION
Do not evaluate the queryset just to find the last pk. 